### PR TITLE
Supress msvc warning

### DIFF
--- a/PicoVM/CLR/crossguid/guid.cxx
+++ b/PicoVM/CLR/crossguid/guid.cxx
@@ -108,7 +108,7 @@ Guid::Guid(const string &fromString)
 {
   _bytes.clear();
 
-  char charOne, charTwo;
+  char charOne = '\0', charTwo;
   bool lookingForFirstChar = true;
 
   for (const char &ch : fromString)


### PR DESCRIPTION
It's safe in our case: because var guard present (lookingForFirstChar)
