### PR TITLE
Partial fix clang windows target

### DIFF
--- a/PicoVM/CLR/Formatting.hxx
+++ b/PicoVM/CLR/Formatting.hxx
@@ -2,7 +2,7 @@
 #define FORMATTING_HXX
 #include <string>
 
-std::string operator "" _s(const char * str, size_t len) {
+inline std::string operator "" _s(const char * str, size_t len) {
     return std::string(str, str + len);
 }
 


### PR DESCRIPTION
Eliminate "multiple definition" error